### PR TITLE
Include workspace-local reverse dependencies in `inspect` output

### DIFF
--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -1,7 +1,9 @@
 use crate::project::{Package, Project, ProjectType};
 use crate::provider::Provider;
 use clap::Args;
+use semver::VersionReq;
 use serde::Serialize;
+use std::collections::BTreeMap;
 use std::path::Path;
 
 /// Display details about current project/package
@@ -51,6 +53,7 @@ struct PackageDetails<'a> {
     bin: bool,
     lib: bool,
     root_package: bool,
+    dependents: &'a BTreeMap<String, VersionReq>,
 }
 
 impl<'a> From<&'a Package> for PackageDetails<'a> {
@@ -61,6 +64,7 @@ impl<'a> From<&'a Package> for PackageDetails<'a> {
             bin: p.is_bin(),
             lib: p.is_lib(),
             root_package: p.is_root_package(),
+            dependents: p.dependents(),
         }
     }
 }

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -113,16 +113,16 @@ impl Project {
                         .insert(md.name.clone(), dep.req.clone());
                 }
             }
-            let pkg = Package::new(md, is_root);
-            let name = pkg.name().to_owned();
-            packages.insert(name, pkg);
+            let name = md.name.clone();
+            packages.insert(name, (md, is_root));
         }
-        for (pkgname, dependents) in rdeps {
-            if let Some(pkg) = packages.get_mut(&pkgname) {
-                pkg.set_dependents(dependents);
-            }
+        let mut package_vec = Vec::with_capacity(packages.len());
+        for (pkgname, (md, root)) in packages {
+            let dependents = rdeps.remove(&pkgname).unwrap_or_default();
+            package_vec.push(Package::new(md, root, dependents));
         }
-        Ok(PackageSet::new(packages.into_values().collect()))
+        // TODO: Warn if `rdeps` is non-empty?
+        Ok(PackageSet::new(package_vec))
     }
 
     pub(crate) fn manifest(&self) -> TextFile<'_, DocumentMut> {

--- a/src/project/package.rs
+++ b/src/project/package.rs
@@ -9,7 +9,8 @@ use crate::util::CopyrightLine;
 use anyhow::{bail, Context};
 use cargo_metadata::{Package as CargoPackage, TargetKind};
 use in_place::InPlace;
-use semver::Version;
+use semver::{Version, VersionReq};
+use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 use toml_edit::DocumentMut;
@@ -18,11 +19,20 @@ use toml_edit::DocumentMut;
 pub(crate) struct Package {
     metadata: CargoPackage,
     is_root: bool,
+    dependents: BTreeMap<String, VersionReq>,
 }
 
 impl Package {
     pub(crate) fn new(metadata: CargoPackage, is_root: bool) -> Package {
-        Package { metadata, is_root }
+        Package {
+            metadata,
+            is_root,
+            dependents: BTreeMap::new(),
+        }
+    }
+
+    pub(super) fn set_dependents(&mut self, dependents: BTreeMap<String, VersionReq>) {
+        self.dependents = dependents;
     }
 
     #[allow(dead_code)]
@@ -70,6 +80,10 @@ impl Package {
 
     pub(crate) fn is_root_package(&self) -> bool {
         self.is_root
+    }
+
+    pub(crate) fn dependents(&self) -> &BTreeMap<String, VersionReq> {
+        &self.dependents
     }
 
     pub(crate) fn changelog(&self) -> TextFile<'_, Changelog> {

--- a/src/project/package.rs
+++ b/src/project/package.rs
@@ -23,16 +23,16 @@ pub(crate) struct Package {
 }
 
 impl Package {
-    pub(crate) fn new(metadata: CargoPackage, is_root: bool) -> Package {
+    pub(super) fn new(
+        metadata: CargoPackage,
+        is_root: bool,
+        dependents: BTreeMap<String, VersionReq>,
+    ) -> Package {
         Package {
             metadata,
             is_root,
-            dependents: BTreeMap::new(),
+            dependents,
         }
-    }
-
-    pub(super) fn set_dependents(&mut self, dependents: BTreeMap<String, VersionReq>) {
-        self.dependents = dependents;
     }
 
     #[allow(dead_code)]

--- a/tests/data/inspect/package-repo/root-workspace.json
+++ b/tests/data/inspect/package-repo/root-workspace.json
@@ -8,7 +8,8 @@
     "manifest_path": "{root}/Cargo.toml",
     "bin": false,
     "lib": true,
-    "root_package": true
+    "root_package": true,
+    "dependents": {}
   },
   "packages": [
     {
@@ -16,7 +17,8 @@
       "manifest_path": "{root}/Cargo.toml",
       "bin": false,
       "lib": true,
-      "root_package": true
+      "root_package": true,
+      "dependents": {}
     }
   ]
 }

--- a/tests/data/inspect/package-repo/root.json
+++ b/tests/data/inspect/package-repo/root.json
@@ -8,6 +8,7 @@
     "manifest_path": "{root}/Cargo.toml",
     "bin": false,
     "lib": true,
-    "root_package": true
+    "root_package": true,
+    "dependents": {}
   }
 }

--- a/tests/data/inspect/package/root-workspace.json
+++ b/tests/data/inspect/package/root-workspace.json
@@ -8,7 +8,8 @@
     "manifest_path": "{root}/Cargo.toml",
     "bin": false,
     "lib": true,
-    "root_package": true
+    "root_package": true,
+    "dependents": {}
   },
   "packages": [
     {
@@ -16,7 +17,8 @@
       "manifest_path": "{root}/Cargo.toml",
       "bin": false,
       "lib": true,
-      "root_package": true
+      "root_package": true,
+      "dependents": {}
     }
   ]
 }

--- a/tests/data/inspect/package/root.json
+++ b/tests/data/inspect/package/root.json
@@ -8,6 +8,7 @@
     "manifest_path": "{root}/Cargo.toml",
     "bin": false,
     "lib": true,
-    "root_package": true
+    "root_package": true,
+    "dependents": {}
   }
 }

--- a/tests/data/inspect/virtual-repo/bin-crate-workspace.json
+++ b/tests/data/inspect/virtual-repo/bin-crate-workspace.json
@@ -8,22 +8,27 @@
     "manifest_path": "{root}/crates/cli/Cargo.toml",
     "bin": true,
     "lib": false,
-    "root_package": false
+    "root_package": false,
+    "dependents": {}
   },
   "packages": [
-    {
-      "name": "fibonacci-cli",
-      "manifest_path": "{root}/crates/cli/Cargo.toml",
-      "bin": true,
-      "lib": false,
-      "root_package": false
-    },
     {
       "name": "fibonacci",
       "manifest_path": "{root}/crates/fibonacci/Cargo.toml",
       "bin": false,
       "lib": true,
-      "root_package": false
+      "root_package": false,
+      "dependents": {
+        "fibonacci-cli": "^0.1.0"
+      }
+    },
+    {
+      "name": "fibonacci-cli",
+      "manifest_path": "{root}/crates/cli/Cargo.toml",
+      "bin": true,
+      "lib": false,
+      "root_package": false,
+      "dependents": {}
     }
   ]
 }

--- a/tests/data/inspect/virtual-repo/bin-crate.json
+++ b/tests/data/inspect/virtual-repo/bin-crate.json
@@ -8,6 +8,7 @@
     "manifest_path": "{root}/crates/cli/Cargo.toml",
     "bin": true,
     "lib": false,
-    "root_package": false
+    "root_package": false,
+    "dependents": {}
   }
 }

--- a/tests/data/inspect/virtual-repo/lib-crate-workspace.json
+++ b/tests/data/inspect/virtual-repo/lib-crate-workspace.json
@@ -8,22 +8,29 @@
     "manifest_path": "{root}/crates/fibonacci/Cargo.toml",
     "bin": false,
     "lib": true,
-    "root_package": false
+    "root_package": false,
+    "dependents": {
+      "fibonacci-cli": "^0.1.0"
+    }
   },
   "packages": [
-    {
-      "name": "fibonacci-cli",
-      "manifest_path": "{root}/crates/cli/Cargo.toml",
-      "bin": true,
-      "lib": false,
-      "root_package": false
-    },
     {
       "name": "fibonacci",
       "manifest_path": "{root}/crates/fibonacci/Cargo.toml",
       "bin": false,
       "lib": true,
-      "root_package": false
+      "root_package": false,
+      "dependents": {
+        "fibonacci-cli": "^0.1.0"
+      }
+    },
+    {
+      "name": "fibonacci-cli",
+      "manifest_path": "{root}/crates/cli/Cargo.toml",
+      "bin": true,
+      "lib": false,
+      "root_package": false,
+      "dependents": {}
     }
   ]
 }

--- a/tests/data/inspect/virtual-repo/lib-crate.json
+++ b/tests/data/inspect/virtual-repo/lib-crate.json
@@ -8,6 +8,9 @@
     "manifest_path": "{root}/crates/fibonacci/Cargo.toml",
     "bin": false,
     "lib": true,
-    "root_package": false
+    "root_package": false,
+    "dependents": {
+      "fibonacci-cli": "^0.1.0"
+    }
   }
 }

--- a/tests/data/inspect/virtual-repo/root-workspace.json
+++ b/tests/data/inspect/virtual-repo/root-workspace.json
@@ -6,18 +6,22 @@
   "current_package": null,
   "packages": [
     {
-      "name": "fibonacci-cli",
-      "manifest_path": "{root}/crates/cli/Cargo.toml",
-      "bin": true,
-      "lib": false,
-      "root_package": false
-    },
-    {
       "name": "fibonacci",
       "manifest_path": "{root}/crates/fibonacci/Cargo.toml",
       "bin": false,
       "lib": true,
-      "root_package": false
+      "root_package": false,
+      "dependents": {
+        "fibonacci-cli": "^0.1.0"
+      }
+    },
+    {
+      "name": "fibonacci-cli",
+      "manifest_path": "{root}/crates/cli/Cargo.toml",
+      "bin": true,
+      "lib": false,
+      "root_package": false,
+      "dependents": {}
     }
   ]
 }

--- a/tests/data/inspect/virtual/bin-crate-workspace.json
+++ b/tests/data/inspect/virtual/bin-crate-workspace.json
@@ -8,22 +8,27 @@
     "manifest_path": "{root}/crates/cli/Cargo.toml",
     "bin": true,
     "lib": false,
-    "root_package": false
+    "root_package": false,
+    "dependents": {}
   },
   "packages": [
-    {
-      "name": "fibonacci-cli",
-      "manifest_path": "{root}/crates/cli/Cargo.toml",
-      "bin": true,
-      "lib": false,
-      "root_package": false
-    },
     {
       "name": "fibonacci",
       "manifest_path": "{root}/crates/fibonacci/Cargo.toml",
       "bin": false,
       "lib": true,
-      "root_package": false
+      "root_package": false,
+      "dependents": {
+        "fibonacci-cli": "^0.1.0"
+      }
+    },
+    {
+      "name": "fibonacci-cli",
+      "manifest_path": "{root}/crates/cli/Cargo.toml",
+      "bin": true,
+      "lib": false,
+      "root_package": false,
+      "dependents": {}
     }
   ]
 }

--- a/tests/data/inspect/virtual/bin-crate.json
+++ b/tests/data/inspect/virtual/bin-crate.json
@@ -8,6 +8,7 @@
     "manifest_path": "{root}/crates/cli/Cargo.toml",
     "bin": true,
     "lib": false,
-    "root_package": false
+    "root_package": false,
+    "dependents": {}
   }
 }

--- a/tests/data/inspect/virtual/lib-crate-workspace.json
+++ b/tests/data/inspect/virtual/lib-crate-workspace.json
@@ -8,22 +8,29 @@
     "manifest_path": "{root}/crates/fibonacci/Cargo.toml",
     "bin": false,
     "lib": true,
-    "root_package": false
+    "root_package": false,
+    "dependents": {
+      "fibonacci-cli": "^0.1.0"
+    }
   },
   "packages": [
-    {
-      "name": "fibonacci-cli",
-      "manifest_path": "{root}/crates/cli/Cargo.toml",
-      "bin": true,
-      "lib": false,
-      "root_package": false
-    },
     {
       "name": "fibonacci",
       "manifest_path": "{root}/crates/fibonacci/Cargo.toml",
       "bin": false,
       "lib": true,
-      "root_package": false
+      "root_package": false,
+      "dependents": {
+        "fibonacci-cli": "^0.1.0"
+      }
+    },
+    {
+      "name": "fibonacci-cli",
+      "manifest_path": "{root}/crates/cli/Cargo.toml",
+      "bin": true,
+      "lib": false,
+      "root_package": false,
+      "dependents": {}
     }
   ]
 }

--- a/tests/data/inspect/virtual/lib-crate.json
+++ b/tests/data/inspect/virtual/lib-crate.json
@@ -8,6 +8,9 @@
     "manifest_path": "{root}/crates/fibonacci/Cargo.toml",
     "bin": false,
     "lib": true,
-    "root_package": false
+    "root_package": false,
+    "dependents": {
+      "fibonacci-cli": "^0.1.0"
+    }
   }
 }

--- a/tests/data/inspect/virtual/root-workspace.json
+++ b/tests/data/inspect/virtual/root-workspace.json
@@ -6,18 +6,22 @@
   "current_package": null,
   "packages": [
     {
-      "name": "fibonacci-cli",
-      "manifest_path": "{root}/crates/cli/Cargo.toml",
-      "bin": true,
-      "lib": false,
-      "root_package": false
-    },
-    {
       "name": "fibonacci",
       "manifest_path": "{root}/crates/fibonacci/Cargo.toml",
       "bin": false,
       "lib": true,
-      "root_package": false
+      "root_package": false,
+      "dependents": {
+        "fibonacci-cli": "^0.1.0"
+      }
+    },
+    {
+      "name": "fibonacci-cli",
+      "manifest_path": "{root}/crates/cli/Cargo.toml",
+      "bin": true,
+      "lib": false,
+      "root_package": false,
+      "dependents": {}
     }
   ]
 }

--- a/tests/data/inspect/workspace-repo/bin-crate-workspace.json
+++ b/tests/data/inspect/workspace-repo/bin-crate-workspace.json
@@ -8,22 +8,27 @@
     "manifest_path": "{root}/cli/Cargo.toml",
     "bin": true,
     "lib": false,
-    "root_package": false
+    "root_package": false,
+    "dependents": {}
   },
   "packages": [
-    {
-      "name": "fibonacci-cli",
-      "manifest_path": "{root}/cli/Cargo.toml",
-      "bin": true,
-      "lib": false,
-      "root_package": false
-    },
     {
       "name": "fibonacci",
       "manifest_path": "{root}/Cargo.toml",
       "bin": false,
       "lib": true,
-      "root_package": true
+      "root_package": true,
+      "dependents": {
+        "fibonacci-cli": "^0.1.0"
+      }
+    },
+    {
+      "name": "fibonacci-cli",
+      "manifest_path": "{root}/cli/Cargo.toml",
+      "bin": true,
+      "lib": false,
+      "root_package": false,
+      "dependents": {}
     }
   ]
 }

--- a/tests/data/inspect/workspace-repo/bin-crate.json
+++ b/tests/data/inspect/workspace-repo/bin-crate.json
@@ -8,6 +8,7 @@
     "manifest_path": "{root}/cli/Cargo.toml",
     "bin": true,
     "lib": false,
-    "root_package": false
+    "root_package": false,
+    "dependents": {}
   }
 }

--- a/tests/data/inspect/workspace-repo/root-workspace.json
+++ b/tests/data/inspect/workspace-repo/root-workspace.json
@@ -8,22 +8,29 @@
     "manifest_path": "{root}/Cargo.toml",
     "bin": false,
     "lib": true,
-    "root_package": true
+    "root_package": true,
+    "dependents": {
+      "fibonacci-cli": "^0.1.0"
+    }
   },
   "packages": [
-    {
-      "name": "fibonacci-cli",
-      "manifest_path": "{root}/cli/Cargo.toml",
-      "bin": true,
-      "lib": false,
-      "root_package": false
-    },
     {
       "name": "fibonacci",
       "manifest_path": "{root}/Cargo.toml",
       "bin": false,
       "lib": true,
-      "root_package": true
+      "root_package": true,
+      "dependents": {
+        "fibonacci-cli": "^0.1.0"
+      }
+    },
+    {
+      "name": "fibonacci-cli",
+      "manifest_path": "{root}/cli/Cargo.toml",
+      "bin": true,
+      "lib": false,
+      "root_package": false,
+      "dependents": {}
     }
   ]
 }

--- a/tests/data/inspect/workspace-repo/root.json
+++ b/tests/data/inspect/workspace-repo/root.json
@@ -8,6 +8,9 @@
     "manifest_path": "{root}/Cargo.toml",
     "bin": false,
     "lib": true,
-    "root_package": true
+    "root_package": true,
+    "dependents": {
+      "fibonacci-cli": "^0.1.0"
+    }
   }
 }

--- a/tests/data/inspect/workspace/bin-crate-workspace.json
+++ b/tests/data/inspect/workspace/bin-crate-workspace.json
@@ -8,22 +8,27 @@
     "manifest_path": "{root}/cli/Cargo.toml",
     "bin": true,
     "lib": false,
-    "root_package": false
+    "root_package": false,
+    "dependents": {}
   },
   "packages": [
-    {
-      "name": "fibonacci-cli",
-      "manifest_path": "{root}/cli/Cargo.toml",
-      "bin": true,
-      "lib": false,
-      "root_package": false
-    },
     {
       "name": "fibonacci",
       "manifest_path": "{root}/Cargo.toml",
       "bin": false,
       "lib": true,
-      "root_package": true
+      "root_package": true,
+      "dependents": {
+        "fibonacci-cli": "^0.1.0"
+      }
+    },
+    {
+      "name": "fibonacci-cli",
+      "manifest_path": "{root}/cli/Cargo.toml",
+      "bin": true,
+      "lib": false,
+      "root_package": false,
+      "dependents": {}
     }
   ]
 }

--- a/tests/data/inspect/workspace/bin-crate.json
+++ b/tests/data/inspect/workspace/bin-crate.json
@@ -8,6 +8,7 @@
     "manifest_path": "{root}/cli/Cargo.toml",
     "bin": true,
     "lib": false,
-    "root_package": false
+    "root_package": false,
+    "dependents": {}
   }
 }

--- a/tests/data/inspect/workspace/root-workspace.json
+++ b/tests/data/inspect/workspace/root-workspace.json
@@ -8,22 +8,29 @@
     "manifest_path": "{root}/Cargo.toml",
     "bin": false,
     "lib": true,
-    "root_package": true
+    "root_package": true,
+    "dependents": {
+      "fibonacci-cli": "^0.1.0"
+    }
   },
   "packages": [
-    {
-      "name": "fibonacci-cli",
-      "manifest_path": "{root}/cli/Cargo.toml",
-      "bin": true,
-      "lib": false,
-      "root_package": false
-    },
     {
       "name": "fibonacci",
       "manifest_path": "{root}/Cargo.toml",
       "bin": false,
       "lib": true,
-      "root_package": true
+      "root_package": true,
+      "dependents": {
+        "fibonacci-cli": "^0.1.0"
+      }
+    },
+    {
+      "name": "fibonacci-cli",
+      "manifest_path": "{root}/cli/Cargo.toml",
+      "bin": true,
+      "lib": false,
+      "root_package": false,
+      "dependents": {}
     }
   ]
 }

--- a/tests/data/inspect/workspace/root.json
+++ b/tests/data/inspect/workspace/root.json
@@ -8,6 +8,9 @@
     "manifest_path": "{root}/Cargo.toml",
     "bin": false,
     "lib": true,
-    "root_package": true
+    "root_package": true,
+    "dependents": {
+      "fibonacci-cli": "^0.1.0"
+    }
   }
 }


### PR DESCRIPTION
Also, sort `"packages"` list in `inspect` output by name.