### PR TITLE
When bumping release versions, bump incompatible dependents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ v0.5.0 (in development)
     - Added `--workspace` option for setting MSRV workspace-wide
 - Added workspace support to `mkgithub`
 - `mkgithub`: Added `--plan-only` option
+- When running `release` in a workspace, dependents with version requirements
+  that are incompatible with the new or post-release version have their version
+  requirements updated
 
 v0.4.0 (2024-12-17)
 -------------------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,6 +924,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,6 +1267,7 @@ dependencies = [
  "in-place",
  "include_dir",
  "indenter",
+ "indoc",
  "itertools",
  "log",
  "mime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ winnow = "0.6.15"
 assert_cmd = "2.0.14"
 assert_fs = "1.1.1"
 cfg-if = "1.0.0"
+indoc = "2.0.5"
 predicates = { version = "3.1.0", default-features = false }
 rstest = { version = "0.23.0", default-features = false }
 similar = "2.5.0"

--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ This command performs the following operations in order:
 - The version field in `Cargo.toml` is set to the release version.  If the
   project contains a `Cargo.lock` file, the version therein is set as well.
 
+    - If operating in a workspace, any packages in the workspace that depend on
+      the package being released have their dependency requirements updated to
+      the new version if they're not already compatible with it.
+
 - If `CHANGELOG.md` exists, the header for the topmost section is edited to
   contain the release version and the current date.  It is an error if the
   topmost section header already contains a date.
@@ -299,7 +303,8 @@ This command performs the following operations in order:
 
     - The version field in `Cargo.toml` (and `Cargo.lock`, if present) is set
       to the next minor version after the just-released version, plus a "-dev"
-      prerelease segment.
+      prerelease segment.  In a workspace, versions required by dependent
+      packages are updated as well.
 
     - If a `CHANGELOG.md` file does not exist, one is created with a section
       for the release that was just made (with text set to "Initial release").

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -378,8 +378,7 @@ fn bump_dependents(
     for (rname, req) in package.dependents() {
         if !req.matches(version) {
             let Some(rpkg) = pkgset.package_by_name(rname) else {
-                // TODO: Error? Warn?
-                continue;
+                bail!("Inconsistent project metadata: {name} is depended on by {rname}, but the latter was not found");
             };
             log::info!("Updating {rname}'s dependency on {name} ...");
             rpkg.set_dependency_version(name, version.to_string())?;

--- a/src/project/package.rs
+++ b/src/project/package.rs
@@ -150,8 +150,8 @@ impl Package {
                 toml_edit::Item::Value(toml_edit::Value::String(_)) => {
                     tbl.insert(package, toml_edit::value(req.clone()));
                 }
-                toml_edit::Item::Table(t) => {
-                    t.insert("version", toml_edit::value(req.clone()));
+                toml_edit::Item::Value(toml_edit::Value::InlineTable(t)) => {
+                    t.insert("version", req.clone().into());
                 }
                 _ => bail!("{tblname}.{package} in Cargo.toml is not a string or table"),
             }
@@ -230,8 +230,8 @@ impl HasReadme for Package {
 mod tests {
     use super::*;
     use crate::project::Project;
-    use assert_fs::prelude::*;
-    use assert_fs::{fixture::ChildPath, TempDir};
+    use assert_fs::{fixture::ChildPath, prelude::*, TempDir};
+    use indoc::indoc;
 
     struct TestPackage {
         package: Package,
@@ -260,111 +260,277 @@ mod tests {
         }
     }
 
-    #[test]
-    fn set_cargo_version() {
-        let tpkg = TestPackage::new(concat!(
-            "[package]\n",
-            "name = \"foobar\"\n",
-            "version = \"0.1.0\"\n",
-            "edition = \"2021\"\n",
-            "\n",
-            "[dependencies]\n",
-        ));
-        tpkg.package
-            .set_cargo_version(Version::new(1, 2, 3), false)
-            .unwrap();
-        tpkg.manifest.assert(concat!(
-            "[package]\n",
-            "name = \"foobar\"\n",
-            "version = \"1.2.3\"\n",
-            "edition = \"2021\"\n",
-            "\n",
-            "[dependencies]\n",
-        ));
-    }
+    mod set_cargo_version {
+        use super::*;
 
-    #[test]
-    fn set_cargo_version_inline() {
-        let tpkg = TestPackage::new("package = { name = \"foobar\", version = \"0.1.0\", edition = \"2021\" }\ndependencies = {}\n");
-        tpkg.package
-            .set_cargo_version(Version::new(1, 2, 3), false)
-            .unwrap();
-        tpkg.manifest.assert("package = { name = \"foobar\", version = \"1.2.3\", edition = \"2021\" }\ndependencies = {}\n");
-    }
+        #[test]
+        fn normal() {
+            let tpkg = TestPackage::new(indoc! {r#"
+                [package]
+                name = "foobar"
+                version = "0.1.0"
+                edition = "2021"
 
-    #[test]
-    fn set_cargo_version_unset() {
-        let tpkg = TestPackage::new(concat!(
-            "[package]\n",
-            "name = \"foobar\"\n",
-            "edition = \"2021\"\n",
-            "\n",
-            "[dependencies]\n",
-        ));
-        tpkg.package
-            .set_cargo_version(Version::new(1, 2, 3), false)
-            .unwrap();
-        tpkg.manifest.assert(concat!(
-            "[package]\n",
-            "name = \"foobar\"\n",
-            "edition = \"2021\"\n",
-            "version = \"1.2.3\"\n",
-            "\n",
-            "[dependencies]\n",
-        ));
-    }
+                [dependencies]
+            "#});
+            tpkg.package
+                .set_cargo_version(Version::new(1, 2, 3), false)
+                .unwrap();
+            tpkg.manifest.assert(indoc! {r#"
+                [package]
+                name = "foobar"
+                version = "1.2.3"
+                edition = "2021"
 
-    #[test]
-    #[ignore] // TODO: Update or remove
-    fn set_cargo_version_no_package() {
-        let tpkg = TestPackage::new("[dependencies]\n");
-        assert!(tpkg
-            .package
-            .set_cargo_version(Version::new(1, 2, 3), false)
-            .is_err());
-        tpkg.manifest.assert("[dependencies]\n");
-    }
+                [dependencies]
+            "#});
+        }
 
-    #[test]
-    #[ignore] // TODO: Update or remove
-    fn set_cargo_version_package_not_table() {
-        let tpkg = TestPackage::new("package = 42\n");
-        assert!(tpkg
-            .package
-            .set_cargo_version(Version::new(1, 2, 3), false)
-            .is_err());
-        tpkg.manifest.assert("package = 42\n");
+        #[test]
+        fn inline() {
+            let tpkg = TestPackage::new("package = { name = \"foobar\", version = \"0.1.0\", edition = \"2021\" }\ndependencies = {}\n");
+            tpkg.package
+                .set_cargo_version(Version::new(1, 2, 3), false)
+                .unwrap();
+            tpkg.manifest.assert("package = { name = \"foobar\", version = \"1.2.3\", edition = \"2021\" }\ndependencies = {}\n");
+        }
+
+        #[test]
+        fn unset() {
+            let tpkg = TestPackage::new(indoc! {r#"
+                [package]
+                name = "foobar"
+                edition = "2021"
+
+                [dependencies]
+            "#});
+            tpkg.package
+                .set_cargo_version(Version::new(1, 2, 3), false)
+                .unwrap();
+            tpkg.manifest.assert(indoc! {r#"
+                [package]
+                name = "foobar"
+                edition = "2021"
+                version = "1.2.3"
+
+                [dependencies]
+            "#});
+        }
     }
 
     #[test]
     fn update_license_years() {
-        let tpkg = TestPackage::new(concat!(
-            "[package]\n",
-            "name = \"foobar\"\n",
-            "version = \"0.1.0\"\n",
-            "edition = \"2021\"\n",
-            "\n",
-            "[dependencies]\n",
-        ));
+        let tpkg = TestPackage::new(indoc! {r#"
+            [package]
+            name = "foobar"
+            version = "0.1.0"
+            edition = "2021"
+
+            [dependencies]
+        "#});
         let license = tpkg.tmpdir.child("LICENSE");
         license
-            .write_str(concat!(
-                "The Foobar License\n",
-                "\n",
-                "Copyright (c) 2021-2022 John T. Wodder II\n",
-                "Copyright (c) 2020 The Prime Mover and their Agents\n",
-                "\n",
-                "Permission is not granted.\n",
-            ))
+            .write_str(indoc! {"
+                The Foobar License
+
+                Copyright (c) 2021-2022 John T. Wodder II
+                Copyright (c) 2020 The Prime Mover and their Agents
+
+                Permission is not granted.
+            "})
             .unwrap();
         tpkg.package.update_license_years([2023]).unwrap();
-        license.assert(concat!(
-            "The Foobar License\n",
-            "\n",
-            "Copyright (c) 2021-2023 John T. Wodder II\n",
-            "Copyright (c) 2020 The Prime Mover and their Agents\n",
-            "\n",
-            "Permission is not granted.\n",
-        ));
+        license.assert(indoc! {"
+            The Foobar License
+
+            Copyright (c) 2021-2023 John T. Wodder II
+            Copyright (c) 2020 The Prime Mover and their Agents
+
+            Permission is not granted.
+        "});
+    }
+
+    mod set_dependency_version {
+        use super::*;
+
+        #[test]
+        fn normal_dep() {
+            let tpkg = TestPackage::new(indoc! {r#"
+                [package]
+                name = "foobar"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                quux = "0.1.0"
+            "#});
+            tpkg.package
+                .set_dependency_version("quux", "1.2.3")
+                .unwrap();
+            tpkg.manifest.assert(indoc! {r#"
+                [package]
+                name = "foobar"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                quux = "1.2.3"
+            "#});
+        }
+
+        #[test]
+        fn dev_dep() {
+            let tpkg = TestPackage::new(indoc! {r#"
+                [package]
+                name = "foobar"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                quux = "0.1.0"
+
+                [dev-dependencies]
+                glarch = "1.2.3"
+            "#});
+            tpkg.package
+                .set_dependency_version("glarch", "42.0")
+                .unwrap();
+            tpkg.manifest.assert(indoc! {r#"
+                [package]
+                name = "foobar"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                quux = "0.1.0"
+
+                [dev-dependencies]
+                glarch = "42.0"
+            "#});
+        }
+
+        #[test]
+        fn build_dep() {
+            let tpkg = TestPackage::new(indoc! {r#"
+                [package]
+                name = "foobar"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                quux = "0.1.0"
+
+                [build-dependencies]
+                glarch = "1.2.3"
+            "#});
+            tpkg.package
+                .set_dependency_version("glarch", "42.0")
+                .unwrap();
+            tpkg.manifest.assert(indoc! {r#"
+                [package]
+                name = "foobar"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                quux = "0.1.0"
+
+                [build-dependencies]
+                glarch = "42.0"
+            "#});
+        }
+
+        #[test]
+        fn every_dep_type() {
+            let tpkg = TestPackage::new(indoc! {r#"
+                [package]
+                name = "foobar"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                glarch = "1.2.3"
+                quux = "0.1.0"
+
+                [dev-dependencies]
+                glarch = "1.2.3"
+                quux = "0.1.0"
+
+                [build-dependencies]
+                glarch = "1.2.3"
+                quux = "0.1.0"
+            "#});
+            tpkg.package
+                .set_dependency_version("glarch", "42.0")
+                .unwrap();
+            tpkg.manifest.assert(indoc! {r#"
+                [package]
+                name = "foobar"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                glarch = "42.0"
+                quux = "0.1.0"
+
+                [dev-dependencies]
+                glarch = "42.0"
+                quux = "0.1.0"
+
+                [build-dependencies]
+                glarch = "42.0"
+                quux = "0.1.0"
+            "#});
+        }
+
+        #[test]
+        fn table_dep() {
+            let tpkg = TestPackage::new(indoc! {r#"
+                [package]
+                name = "foobar"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                quux = { version = "0.1.0", default-features = false }
+            "#});
+            tpkg.package
+                .set_dependency_version("quux", "1.2.3")
+                .unwrap();
+            tpkg.manifest.assert(indoc! {r#"
+                [package]
+                name = "foobar"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                quux = { version = "1.2.3", default-features = false }
+            "#});
+        }
+
+        #[test]
+        fn table_dep_no_version() {
+            let tpkg = TestPackage::new(indoc! {r#"
+                [package]
+                name = "foobar"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                quux = { path = "../quux", default-features = false }
+            "#});
+            tpkg.package
+                .set_dependency_version("quux", "1.2.3")
+                .unwrap();
+            tpkg.manifest.assert(indoc! {r#"
+                [package]
+                name = "foobar"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                quux = { path = "../quux", default-features = false , version = "1.2.3" }
+            "#});
+        }
     }
 }


### PR DESCRIPTION
Closes #197.

To Do:

- ~Reconsider what the post-release version of a package should be?~ (#216)
- Add tests:
    - [x] Test `set_dependency_version()`
    - ~Test handling of dependents with `path` but not `version` (They should not be modified)~
    - ~Give `release` an option for stopping just before committing, and use this in tests?~
- [x] Update CHANGELOG
- [x] Update README