### PR TITLE
Don't treat `^x.y.z-dev` as accepting `x.y.z`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ v0.6.0 (in development)
 - `mkgithub`: Handle creating repositories without descriptions
 - **Bugfix**: Don't panic when `release` is run on a project whose README lacks
   header links
-- When bumping local workspace inter-dependencies, don't add `version` keys to
-  specifiers that lack them
+- `release`: When bumping local workspace inter-dependencies:
+    - Don't add `version` keys to specifiers that lack them
+    - Don't treat `^x.y.z-dev` as accepting `x.y.z`
 - `release`: Unstash files in `{dir}.stash/` if `cargo publish` fails
 
 v0.5.0 (2025-01-01)


### PR DESCRIPTION
Closes #222.