### PR TITLE
Don't update `Cargo.lock` until after dependents are updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ v0.6.0 (in development)
     - Add `--cfg docsrs` to `RUSTDOCFLAGS`
     - Assume project is always a workspace with features
 - `mkgithub`: Handle creating repositories without descriptions
-- **Bugfix**: Don't panic when `release` is run on a project whose README lacks
-  header links
-- `release`: When bumping local workspace inter-dependencies:
-    - Don't add `version` keys to specifiers that lack them
-    - Don't treat `^x.y.z-dev` as accepting `x.y.z`
-- `release`: Unstash files in `{dir}.stash/` if `cargo publish` fails
+- `release`:
+    - **Bugfix**: Don't panic when run on a project whose README lacks header
+      links
+    - **Bugfix**: When bumping local workspace inter-dependencies:
+        - Don't add `version` keys to specifiers that lack them
+        - Don't treat `^x.y.z-dev` as accepting `x.y.z`
+        - Don't update `Cargo.lock` until after dependents are updated
+    - Unstash files in `{dir}.stash/` if `cargo publish` fails
 
 v0.5.0 (2025-01-01)
 -------------------

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -77,8 +77,12 @@ impl Release {
         let update_lock = project.path().join("Cargo.lock").exists();
         if &new_version != old_version {
             log::info!("Setting version in Cargo.toml ...");
-            package.set_cargo_version(new_version.clone(), update_lock)?;
+            package.set_cargo_version(&new_version)?;
             bump_dependents(&pkgset, package, &new_version)?;
+            if update_lock {
+                // Do this AFTER updating dependents!
+                package.update_lockfile(&new_version)?;
+            }
         }
 
         let release_date = chrono::Local::now().date_naive();
@@ -277,8 +281,12 @@ impl Release {
 
         // Update version in Cargo.toml
         log::info!("Setting next version in Cargo.toml ...");
-        package.set_cargo_version(dev_next.clone(), update_lock)?;
+        package.set_cargo_version(&dev_next)?;
         bump_dependents(&pkgset, package, &dev_next)?;
+        if update_lock {
+            // Do this AFTER updating dependents!
+            package.update_lockfile(&dev_next)?;
+        }
 
         // Ensure CHANGELOG is present and contains section for upcoming
         // version


### PR DESCRIPTION
Closes #223.